### PR TITLE
Use collections.Iterable instead of list

### DIFF
--- a/numcompress/numcompress.py
+++ b/numcompress/numcompress.py
@@ -1,3 +1,5 @@
+import collections
+
 PRECISION_LOWER_LIMIT=0
 PRECISION_UPPER_LIMIT = 10
 
@@ -6,7 +8,7 @@ def compress(series, precision=3):
     last_num = 0
     result = ''
 
-    if not isinstance(series, list):
+    if not isinstance(series, collections.Iterable):
         raise ValueError('Input to compress should be of type list.')
 
     if not isinstance(precision, int):


### PR DESCRIPTION
In Python 3 range, map, filter are not lists like Python 2 but they are iterable. Using `collections.Iterable` enables us to use  `compress(range(10))`. This makes dictionaries also valid but `for item in series` will bring in only the keys which need to be int as it's validated.

Cool project BTW. I am porting this to Clojure at https://github.com/tirkarthi/numcompress.

Thanks