### PR TITLE
Add support from numpy arrays compression and decompression

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ from numcompress import compress, decompress
 >>> series = np.random.randint(1, 100, 100).reshape(10, 10)
 
 >>> compress_ndarray(series)
-('?S?', 'BozaCninBozaC_~i@nvs@nggA_bxB~}i@ntLotL~kaA_klBninB_pR?~qy@_|BoofBn_h@o~rA~heA~dtB_t`BnxzAokuC_pR~ooCo}}B~dtB_~i@nqP~tu@~uJoe}CnrbB~rN_db@oyo@n}@_xq@~lV~wq@nm_Aoe`@o{vA~s`B~zm@oe`@okX_g^ojcAndkAnp{@~{B_cmA_af@~{_CntLozDohyCn}}B~f^_xnD~`f@?_yF_vJ~tu@oaoA~`cD~uJ_mV_g^?~n}@_acD~yxAodkAn~rAnvs@?__|B~pdBnkX_{jD~iZ~rNnnTokX_vJnnqC_~i@_klB~v|A_~i@_o}@~yxAntL~}i@_fiA')
+'?S?,Bo|k@ojcA~kaAnqPnzD_qdBnqP_~i@n}}B_d_DninB~tu@_mV_uu@_}tAo}@nrbBosw@~yxA_fiAovs@ntiCoe`@_hpBn|hDojcA_{m@~zm@okXovs@~c_DocvB~uJ~rN_uu@owHnp{@ndkA_ieA_{m@ninBo_h@n}@o`zB~rkCoggA_yF_yFndkAo}}B~axBn_h@oe}C?ninB_bxB~wnDnzDom_Aoh\\nwH~|tA_{m@_|_C~wnD_|Bo_h@_ycCnnT_vJ~f^n{vA_|_C~pdBnggA_yFohyCntL~iwCowHodkAnxzA_rvD~ooC~xFne`@_}tA_db@njcAotLo{vAnnqC_{jD~lVninB_cmAnnTovs@~{BnqP'
 
->>> decompress_ndarray('?S?', 'BozaCninBozaC_~i@nvs@nggA_bxB~}i@ntLotL~kaA_klBninB_pR?~qy@_|BoofBn_h@o~rA~heA~dtB_t`BnxzAokuC_pR~ooCo}}B~dtB_~i@nqP~tu@~uJoe}CnrbB~rN_db@oyo@n}@_xq@~lV~wq@nm_Aoe`@o{vA~s`B~zm@oe`@okX_g^ojcAndkAnp{@~{B_cmA_af@~{_CntLozDohyCn}}B~f^_xnD~`f@?_yF_vJ~tu@oaoA~`cD~uJ_mV_g^?~n}@_acD~yxAodkAn~rAnvs@?__|B~pdBnkX_{jD~iZ~rNnnTokX_vJnnqC_~i@_klB~v|A_~i@_o}@~yxAntL~}i@_fiA').shape
+>>> decompress_ndarray('?S?,Bo|k@ojcA~kaAnqPnzD_qdBnqP_~i@n}}B_d_DninB~tu@_mV_uu@_}tAo}@nrbBosw@~yxA_fiAovs@ntiCoe`@_hpBn|hDojcA_{m@~zm@okXovs@~c_DocvB~uJ~rN_uu@owHnp{@ndkA_ieA_{m@ninBo_h@n}@o`zB~rkCoggA_yF_yFndkAo}}B~axBn_h@oe}C?ninB_bxB~wnDnzDom_Aoh\\nwH~|tA_{m@_|_C~wnD_|Bo_h@_ycCnnT_vJ~f^n{vA_|_C~pdBnggA_yFohyCntL~iwCowHodkAnxzA_rvD~ooC~xFne`@_}tA_db@njcAotLo{vAnnqC_{jD~lVninB_cmAnnTovs@~{BnqP').shape
 (10, 10)
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,13 +49,31 @@ from numcompress import compress, decompress
 >>> from numcompress import compress_ndarray, decompress_ndarray
 >>> import numpy as np
 
->>> series = np.random.randint(1, 100, 100).reshape(10, 10)
+>>> series = np.random.randint(1, 100, 25).reshape(5, 5)
 
->>> compress_ndarray(series)
-'?S?,Bo|k@ojcA~kaAnqPnzD_qdBnqP_~i@n}}B_d_DninB~tu@_mV_uu@_}tAo}@nrbBosw@~yxA_fiAovs@ntiCoe`@_hpBn|hDojcA_{m@~zm@okXovs@~c_DocvB~uJ~rN_uu@owHnp{@ndkA_ieA_{m@ninBo_h@n}@o`zB~rkCoggA_yF_yFndkAo}}B~axBn_h@oe}C?ninB_bxB~wnDnzDom_Aoh\\nwH~|tA_{m@_|_C~wnD_|Bo_h@_ycCnnT_vJ~f^n{vA_|_C~pdBnggA_yFohyCntL~iwCowHodkAnxzA_rvD~ooC~xFne`@_}tA_db@njcAotLo{vAnnqC_{jD~lVninB_cmAnnTovs@~{BnqP'
+>>> compressed_series = compress_ndarray(series)
 
->>> decompress_ndarray('?S?,Bo|k@ojcA~kaAnqPnzD_qdBnqP_~i@n}}B_d_DninB~tu@_mV_uu@_}tAo}@nrbBosw@~yxA_fiAovs@ntiCoe`@_hpBn|hDojcA_{m@~zm@okXovs@~c_DocvB~uJ~rN_uu@owHnp{@ndkA_ieA_{m@ninBo_h@n}@o`zB~rkCoggA_yF_yFndkAo}}B~axBn_h@oe}C?ninB_bxB~wnDnzDom_Aoh\\nwH~|tA_{m@_|_C~wnD_|Bo_h@_ycCnnT_vJ~f^n{vA_|_C~pdBnggA_yFohyCntL~iwCowHodkAnxzA_rvD~ooC~xFne`@_}tA_db@njcAotLo{vAnnqC_{jD~lVninB_cmAnnTovs@~{BnqP').shape
-(10, 10)
+>>> decompressed_series = decompress_ndarray(compressed_series)
+
+>>> series
+array([[29, 95, 10, 48, 20],
+       [60, 98, 73, 96, 71],
+       [95, 59,  8,  6, 17],
+       [ 5, 12, 69, 65, 52],
+       [84,  6, 83, 20, 50]])
+
+>>> compressed_series
+'5*5,Bosw@_|_Cn_eD_fiA~tu@_cmA_fiAnyo@o|k@nyo@_{m@~heAnrbB~{BonT~lVotLoinB~xFnkX_o}@~iwCokuCn`zB_ry@'
+
+>>> decompressed_series
+array([[29., 95., 10., 48., 20.],
+       [60., 98., 73., 96., 71.],
+       [95., 59.,  8.,  6., 17.],
+       [ 5., 12., 69., 65., 52.],
+       [84.,  6., 83., 20., 50.]])
+
+>>> (series == decompressed_series).all()
+True
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ from numcompress import compress, decompress
 >>> decompress('Acn[rpB{n@')
 [145.78, 127.6, 135.26]
 
+# compressing and decompressing numpy arrays
+
+>>> from numcompress import compress_ndarray, decompress_ndarray
+>>> import numpy as np
+
+>>> series = np.random.randint(1, 100, 100).reshape(10, 10)
+
+>>> compress_ndarray(series)
+('?S?', 'BozaCninBozaC_~i@nvs@nggA_bxB~}i@ntLotL~kaA_klBninB_pR?~qy@_|BoofBn_h@o~rA~heA~dtB_t`BnxzAokuC_pR~ooCo}}B~dtB_~i@nqP~tu@~uJoe}CnrbB~rN_db@oyo@n}@_xq@~lV~wq@nm_Aoe`@o{vA~s`B~zm@oe`@okX_g^ojcAndkAnp{@~{B_cmA_af@~{_CntLozDohyCn}}B~f^_xnD~`f@?_yF_vJ~tu@oaoA~`cD~uJ_mV_g^?~n}@_acD~yxAodkAn~rAnvs@?__|B~pdBnkX_{jD~iZ~rNnnTokX_vJnnqC_~i@_klB~v|A_~i@_o}@~yxAntL~}i@_fiA')
+
+>>> decompress_ndarray('?S?', 'BozaCninBozaC_~i@nvs@nggA_bxB~}i@ntLotL~kaA_klBninB_pR?~qy@_|BoofBn_h@o~rA~heA~dtB_t`BnxzAokuC_pR~ooCo}}B~dtB_~i@nqP~tu@~uJoe}CnrbB~rN_db@oyo@n}@_xq@~lV~wq@nm_Aoe`@o{vA~s`B~zm@oe`@okX_g^ojcAndkAnp{@~{B_cmA_af@~{_CntLozDohyCn}}B~f^_xnD~`f@?_yF_vJ~tu@oaoA~`cD~uJ_mV_g^?~n}@_acD~yxAodkAn~rAnvs@?__|B~pdBnkX_{jD~iZ~rNnnTokX_vJnnqC_~i@_klB~v|A_~i@_o}@~yxAntL~}i@_fiA').shape
+(10, 10)
 ```
 
 

--- a/numcompress/numcompress.py
+++ b/numcompress/numcompress.py
@@ -2,7 +2,10 @@ import numpy as np
 
 PRECISION_LOWER_LIMIT = 0
 PRECISION_UPPER_LIMIT = 10
-SEPARATOR = ','  # This char should have Unicode code point in the range [32, 63) to avoid overlaps.
+
+# Used for N-Dimensional array. Separates dimension and the series.
+# Should have ASCII value between (0, 63) to avoid overlapping with regular compress output.
+SEPARATOR = ','
 
 
 def compress(series, precision=3):
@@ -87,11 +90,11 @@ def decompress_number(text, index):
 
 
 def compress_ndarray(series, precision=3):
-    return f'{compress(list(series.shape), precision=0)}{SEPARATOR}{compress(series.flatten().tolist(), precision)}'
+    return f'{"*".join(map(str, series.shape))}{SEPARATOR}{compress(series.flatten().tolist(), precision)}'
 
 
 def decompress_ndarray(text):
-    shape_text, series_text = text.split(SEPARATOR)
-    shape = decompress(shape_text)
+    shape_str, series_text = text.split(SEPARATOR)
+    shape = tuple(int(dimension) for dimension in shape_str.split('*'))
     series = decompress(series_text)
     return np.array(series).reshape(*shape)

--- a/numcompress/numcompress.py
+++ b/numcompress/numcompress.py
@@ -1,7 +1,8 @@
 import numpy as np
 
-PRECISION_LOWER_LIMIT=0
+PRECISION_LOWER_LIMIT = 0
 PRECISION_UPPER_LIMIT = 10
+SEPARATOR = ','  # This char should have Unicode code point in the range [32, 63) to avoid overlaps.
 
 
 def compress(series, precision=3):
@@ -30,7 +31,7 @@ def compress(series, precision=3):
 
     for num in series:
         diff = num - last_num
-        diff = int(round(diff * (10**precision)))
+        diff = int(round(diff * (10 ** precision)))
         diff = ~(diff << 1) if diff < 0 else diff << 1
 
         while diff >= 0x20:
@@ -86,10 +87,11 @@ def decompress_number(text, index):
 
 
 def compress_ndarray(series, precision=3):
-    return compress(list(series.shape), precision=0), compress(series.flatten().tolist(), precision)
+    return f'{compress(list(series.shape), precision=0)}{SEPARATOR}{compress(series.flatten().tolist(), precision)}'
 
 
-def decompress_ndarray(shape_text, text):
+def decompress_ndarray(text):
+    shape_text, series_text = text.split(SEPARATOR)
     shape = decompress(shape_text)
-    series = decompress(text)
+    series = decompress(series_text)
     return np.array(series).reshape(*shape)

--- a/numcompress/numcompress.py
+++ b/numcompress/numcompress.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 PRECISION_LOWER_LIMIT=0
 PRECISION_UPPER_LIMIT = 10
 
@@ -81,3 +83,13 @@ def decompress_number(text, index):
             break
 
     return index, (~result >> 1) if (result & 1) != 0 else (result >> 1)
+
+
+def compress_ndarray(series, precision=3):
+    return compress(list(series.shape), precision=0), compress(series.flatten().tolist(), precision)
+
+
+def decompress_ndarray(shape_text, text):
+    shape = decompress(shape_text)
+    series = decompress(text)
+    return np.array(series).reshape(*shape)

--- a/numcompress/numcompress.py
+++ b/numcompress/numcompress.py
@@ -90,7 +90,9 @@ def decompress_number(text, index):
 
 
 def compress_ndarray(series, precision=3):
-    return f'{"*".join(map(str, series.shape))}{SEPARATOR}{compress(series.flatten().tolist(), precision)}'
+    shape = "*".join(map(str, series.shape))
+    series_compressed = compress(series.flatten().tolist(), precision)
+    return '{}{}{}'.format(shape, SEPARATOR, series_compressed )
 
 
 def decompress_ndarray(text):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ try:
 except ImportError:
     from distutils.core import setup
 
-
 setup(
     name='numcompress',
     packages=['numcompress'],
@@ -15,5 +14,6 @@ setup(
     license='MIT',
     download_url='',
     keywords=['compression', 'numerical', 'numbers into text'],
-    classifiers=[]
+    classifiers=[],
+    install_requires=['numpy'],
 )

--- a/test/test_numcompress.py
+++ b/test/test_numcompress.py
@@ -105,4 +105,4 @@ class TestNumCompress(unittest.TestCase):
 
     def test_compress_decompress_works_with_numpy_array(self):
         series = np.random.randint(1, 100, 100).reshape(10, 10)
-        assert (decompress_ndarray(*compress_ndarray(series)) == series).all()
+        assert (decompress_ndarray(compress_ndarray(series)) == series).all()

--- a/test/test_numcompress.py
+++ b/test/test_numcompress.py
@@ -1,8 +1,9 @@
 import unittest
 import random
 import sys
+import numpy as np
 import pytest
-from numcompress import compress, decompress
+from numcompress import compress, decompress, compress_ndarray, decompress_ndarray
 
 
 class TestNumCompress(unittest.TestCase):
@@ -101,3 +102,7 @@ class TestNumCompress(unittest.TestCase):
     def test_decompress_invalid_text_input_raises_exception(self):
         with pytest.raises(ValueError):
             decompress('^fhfjelr;')
+
+    def test_compress_decompress_works_with_numpy_array(self):
+        series = np.random.randint(1, 100, 100).reshape(10, 10)
+        assert (decompress_ndarray(*compress_ndarray(series)) == series).all()


### PR DESCRIPTION
The two utility functions `compress_ndarray` and `decompress_ndarray` provide the ability to compress and decompress numpy arrays. These two function provide two main advantages over the original `compress` and `decompress` functions (although they are used internally)":

1. Have better compression ration, as the whole  ndarray is compressed to single string.
2. More friendly api to work with numpy arrays regardless of their shapes. 
